### PR TITLE
Implement get_location for Token

### DIFF
--- a/brack-tokenizer/src/tokens.rs
+++ b/brack-tokenizer/src/tokens.rs
@@ -40,3 +40,24 @@ pub fn mock_location() -> Location {
         },
     }
 }
+
+impl Token {
+    pub fn get_location(&self) -> Location {
+        match self {
+            Token::Empty(location) => location.clone(),
+            Token::Text(_, location) => location.clone(),
+            Token::Module(_, location) => location.clone(),
+            Token::Ident(_, location) => location.clone(),
+            Token::NewLine(location) => location.clone(),
+            Token::Dot(location) => location.clone(),
+            Token::AngleBracketOpen(location) => location.clone(),
+            Token::AngleBracketClose(location) => location.clone(),
+            Token::SquareBracketOpen(location) => location.clone(),
+            Token::SquareBracketClose(location) => location.clone(),
+            Token::CurlyBracketOpen(location) => location.clone(),
+            Token::CurlyBracketClose(location) => location.clone(),
+            Token::Comma(location) => location.clone(),
+            Token::EOF(location) => location.clone(),
+        }
+    }
+}


### PR DESCRIPTION
I think it should be given as a function rather than conditional in ParseError::new to get it.